### PR TITLE
Remove `require "pry"` in Client (fixes #5)

### DIFF
--- a/lib/batman_ipsum/client.rb
+++ b/lib/batman_ipsum/client.rb
@@ -1,8 +1,6 @@
 require "open-uri"
 require "json"
 
-require "pry"
-
 module BatmanIpsum
   class Client
     BATMAN_IPSUM_DATA_URI = "http://batman-ipsum.com/data/punch_lines.json".freeze


### PR DESCRIPTION
We don't want `pry` in the final code (see #5)
