### PR TITLE
Fixed typo in "character"

### DIFF
--- a/lib/batman_ipsum/client.rb
+++ b/lib/batman_ipsum/client.rb
@@ -15,7 +15,7 @@ module BatmanIpsum
 
     def fetch_quotes(characters:)
       quote = data["texts"].sample
-      character = (data["characters"].find { |char| char["id"] == quote["id_characte"] } || {})&.fetch("name", nil)
+      character = (data["characters"].find { |char| char["id"] == quote["id_character"] } || {})&.fetch("name", nil)
 
       [Quote.new(text: quote["text"], character: character)]
     end


### PR DESCRIPTION
Fixed a typo which lead to characters not being displayed next to their quotes.
